### PR TITLE
ci: test plugin and rdmo setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - '.github/workflows/**'
       - 'rdmo_radar/**'
+      - 'testing/**'
+      - 'tests/**'
       - .pre-commit-config.yaml
       - pyproject.toml
 
@@ -18,53 +20,55 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHONDONTWRITEBYTECODE: 1
   FORCE_COLOR: 1 # colored output by pytest etc.
-  CLICOLOR_FORCE: 1 # colored output by ruff
 
 jobs:
 
   lint:
-    name: Lint
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "3.12"
-        cache: pip
-    - run: python -m pip install --upgrade pip setuptools wheel
-    - run: python -m pip install -e .[dev]
-    - name: Set up pre-commit cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pre-commit
-        key: lint-${{ hashFiles('.pre-commit-config.yaml') }}
-    - name: Run linters via pre-commit (ruff, eslint)
-      run: pre-commit run --all-files --color=always
+    uses: rdmorganiser/.github/.github/workflows/_lint.yml@main
 
-  dev-setup:
-    # Ref: structlog (MIT licensed) <https://github.com/hynek/structlog/blob/main/.github/workflows/ci.yml>
-    name: "Test dev setup on ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+  test:
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - name: Checkout "testing" directory rdmo repository
+        uses: actions/checkout@v4
+        with:
+          repository: rdmorganiser/rdmo
+          sparse-checkout: testing
+          path: rdmo
+      - name: Merge rdmo/testing with plugin testing directory
+        run: cp -r rdmo/testing/* testing && rm -r rdmo
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: pip
-      - run: python -Im pip install -e .[dev]
-      - run: python -Ic 'import rdmo_radar; print(rdmo_radar.__version__)'
+      - run: python -m pip install --editable ".[dev]"
+      - run: python -m pip list
+      - run: pytest -s
+
+  # dev-setup:
+  #   # Ref: structlog (MIT licensed) <https://github.com/hynek/structlog/blob/main/.github/workflows/ci.yml>
+  #   name: "Test dev setup on ${{ matrix.os }}"
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.12"
+  #         cache: pip
+  #     - run: python -Im pip install -e .[dev]
+  #     - run: python -Ic 'import rdmo_radar; print(rdmo_radar.__version__)'
 
   required-checks-pass:
     if: always()
     needs:
       - lint
-      - dev-setup
-    runs-on: ubuntu-22.04
+      # - dev-setup
+    runs-on: ubuntu-24.04
     steps:
       - uses: re-actors/alls-green@release/v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 /build
 /dist
 /*.egg-info
+
+.ruff_cache
+.pytest_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ ci = [
 ]
 dev = [
   "pre-commit~=3.5",
-  "rdmo[allauth]",
-  "rdmo-plugins-radar[pytest]",
+  "rdmo[dev]~=2.0",
 ]
 
 [project.urls]
@@ -52,9 +51,20 @@ packages = ["rdmo_radar"]
 [tool.setuptools.dynamic]
 version = {attr = "rdmo_radar.__version__"}
 
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "config.settings"
+pythonpath = ["testing"]
+testpaths = ["tests"]
+filterwarnings = [
+  # ignore warnings raised from within coreapi 2.3.3
+  "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
+  "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+]
+
 [tool.ruff]
-target-version = "py38"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions
@@ -74,7 +84,7 @@ ignore = [
   "RUF012", # mutable-class-default
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 section-order = [
   "future",
   "standard-library",
@@ -87,7 +97,7 @@ section-order = [
   "local-folder"
 ]
 
-[tool.ruff.isort.sections]
+[tool.ruff.lint.isort.sections]
 pytest = ["pytest"]
 django = ["django"]
 rest_framework = ["rest_framework"]

--- a/testing/config/settings/local.py
+++ b/testing/config/settings/local.py
@@ -1,0 +1,9 @@
+# ruff: noqa: F821
+
+PROJECT_IMPORTS += [
+    ('radar', _('from RADAR XML'), 'rdmo_radar.imports.RadarImport'),
+]
+PROJECT_EXPORTS += [
+    ('radar-xml', _('as RADAR XML'), 'rdmo_radar.exports.RadarExport'),
+    ('radar', _('directly to RADAR'), 'rdmo_radar.exports.RadarExportProvider'),
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from django.conf import settings
+from django.core.management import call_command
+
+from rdmo.accounts.utils import set_group_permissions
+
+
+@pytest.fixture(scope="session")
+def fixtures():
+    allowed_file_stems = {
+        "accounts",
+        "conditions",
+        "domain",
+        "groups",
+        "options",
+        "overlays",
+        "projects",
+        "questions",
+        "sites",
+        "tasks",
+        "users",
+        "views",
+    }
+    fixtures = []
+    for fixture_dir in settings.FIXTURE_DIRS:
+        filenames = [filename for filename in Path(fixture_dir).iterdir() if filename.stem in allowed_file_stems]
+        fixtures.extend(filenames)
+    return fixtures
+
+
+@pytest.fixture(scope="session")
+def django_db_setup(django_db_setup, django_db_blocker, fixtures):  # noqa: PT004 - pytest-django requires this name "django_db_setup"
+    """Populate database with test data from fixtures directories."""
+    with django_db_blocker.unblock():
+        call_command("loaddata", *fixtures)
+        set_group_permissions()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,20 @@
+import pytest
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
+
+from rdmo.projects.models import Project
+
+
+def test_settings():
+    assert ("radar", _("from RADAR XML"), "rdmo_radar.imports.RadarImport") in settings.PROJECT_IMPORTS
+
+
+@pytest.mark.django_db
+def test_fixtures_are_available():
+    num_users = get_user_model().objects.count()
+    assert num_users > 0
+
+    num_projects = Project.objects.count()
+    assert num_projects > 0


### PR DESCRIPTION
@MyPyDavid: This is a redo of #1.

I looked at what you wanted to achieve and tried to put it in the ci.yml.

The workflow pulls the plugin repo and gets only the `testing` directory from the rdmo repository.

This leads to a "working testing setup", as you can see in the two dummy tests. I test that the plugin settings from local.py are correctly loaded into the django project settings. Also I verify the fixtures get loaded into the database.

This only works in CI though, if you run pytest locally, the rdmo testing directory is not present.

But the setup in #1 only worked in ci as well?

What do you think? Is this the way to go?